### PR TITLE
useEffect

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,12 @@ export default class MyService extends Service {
   @tracked data: { name: string }; // an ember data model for example
 
   effect = this.trackedEffects.addEffect(
+    this, // the service will stop the effect running if the context is destroyed
     () => { 
       // the tracked effects service will watch any tracked data
       // you read here and will run this function whenever it changes
       browser.localStorage.setItem('my-data', this.data?.name ?? '');
-    },
-    this // the service will stop the effect running if the context is destroyed
+    }
   );
 }
 ```
@@ -105,10 +105,10 @@ export default class MyService extends Service {
   @tracked data: { name: string }; 
   
   private effect = this.trackedEffects.addEffect(
+    this,
     () => { 
       browser.localStorage.setItem('my-data', this.data?.name ?? '');
-    },
-    this
+    }
   );
 
   public stopWatching() {

--- a/README.md
+++ b/README.md
@@ -42,6 +42,68 @@ need to call into browser APIs, or embedded platform APIs. In Electron you
 might want to make changes to the file system based on data changes, or 
 system clock for example. 
 
+## `useEffect` usage
+
+Sometimes you may need to make some changes after some tracked property is changed that is not controlled in the current component or the model. So instead of writing `{{did-insert}}` and `{{did-update @someProp}}` modifiers you can write an effect on the code level. Be careful with dependencies you have there, incorrect usage may lead to circular re-rendering.
+
+`useEffect` is received 3 arguments:
+- **context** - required, destroyable object
+- **effect** - required, this effect is called whenever the observed tracked properties are updated.
+- **deps** - optional, this function should always return an array of tracked properties.
+  
+`useEffect` can be **autotracked** or **controlled**
+1. To have a **controlled** effect you'll need to pass the `deps` function (`() => [trackedProp1, trackedProp2]`). If any of these properties is updated it'll trigger the new effect.
+   Note, the property can be updated, but the value can be the same (`this.prop = this.prop`), it'll trigger the effect anyway. To prevent this you can use the `dedupeTracked` decorator from https://github.com/tracked-tools/tracked-toolbox instead. 
+   
+   To have the effect on mount only, pass the function with empty array (`() => []`).
+   
+   Passing non-tracked properties to this array has no effect on updates.
+   
+   The deps array is also passed to the effect function as arguments. (`useEffect(this, (prop1, prop2) => {...}, () => [prop1, prop2]`)
+2. If you don't pass the deps argument, the effect will be **autotracked**, so it will trigger the function whenever any tracked property in the effect is updated.
+   
+   Be careful with this effect if you are using more than 1 tracked property inside the effect as it can be complicated to investigate what property triggers the update. Use controlled effect there instead.
+
+```ts
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { useEffect } from 'ember-tracked-effects-placeholder';
+
+interface Args {
+  id: string;
+}
+
+export default class MyComponent extends Component<Args> {
+  @tracked input = '';
+
+  constructor(owner, args) {
+    super(owner, args);
+    
+    // constructor style
+    useEffect(this, () => {
+      // some code
+    });
+  }
+  
+  /* property assignment style */
+
+  autotrackedEffect = useEffect(this, () => {
+    console.log('this is called whenever @id or this.input is updated');
+    console.log(this.args.id, this.input); // consume this.args.id and this.input
+  }); // no consumer
+
+  mountEffect = useEffect(this, () => {
+    console.log('this is called only on mount and is neved updated');
+    console.log(this.args.id, this.input); // it doesn't matter what you call here
+  }, () => []); // empty array consumer
+
+  idEffect = useEffect(this, () => {
+    console.log('this is called whenever @id is updated');
+    console.log('it is safe to use any other tracked properties', this.args.id, this.input);
+  }, () => [this.args.id]); // consume @id only
+}
+```
+
 ## Usage with a decorator
 
 In a service, use the `@effect` decorator on a function property. 

--- a/addon/classes/tracked-effect-decorator.ts
+++ b/addon/classes/tracked-effect-decorator.ts
@@ -13,7 +13,7 @@ export default function effect(this: any, target: any, propertyKey: string, desc
     descriptor.initializer = function() {
       var fn = oldInit?.call(this);
       if (fn) {
-        TrackedEffectsCore.instance?.addEffect(fn, this);    
+        TrackedEffectsCore.instance?.addEffect(this, fn);
       }
       return fn;
     };

--- a/addon/classes/tracked-effects-core.ts
+++ b/addon/classes/tracked-effects-core.ts
@@ -1,5 +1,5 @@
 import { assert } from "@ember/debug";
-import TrackedEffect from "./tracked-effect";
+import TrackedEffect, { EffectDeps, EffectCallback } from './tracked-effect';
 import { run, scheduleOnce } from "@ember/runloop";
 import { action } from "@ember/object";
 
@@ -21,9 +21,9 @@ export default class TrackedEffectsCore {
     return this.watching;
   }
 
-  public addEffect(context: object, runFn: Function): TrackedEffect {
+  public addEffect<D extends any[]>(context: object, runFn: EffectCallback<D>, deps?: EffectDeps<D>): TrackedEffect<D> {
     assert('You cannot add an effect without providing a function', runFn);
-    var effect = new TrackedEffect({ runFn, context });
+    var effect = new TrackedEffect({ runFn, context, deps });
     this.effects.set(effect.id, effect);
     effect.run;
     this.startWatching();

--- a/addon/classes/tracked-effects-core.ts
+++ b/addon/classes/tracked-effects-core.ts
@@ -6,7 +6,7 @@ import { action } from "@ember/object";
 export default class TrackedEffectsCore {
 
   public static instance?: TrackedEffectsCore;
-  
+
   private watching: boolean = false;
 
   private effects: Map<string, TrackedEffect> = new Map<string, TrackedEffect>();
@@ -21,7 +21,7 @@ export default class TrackedEffectsCore {
     return this.watching;
   }
 
-  public addEffect(runFn: Function, context?: object): TrackedEffect {
+  public addEffect(context: object, runFn: Function): TrackedEffect {
     assert('You cannot add an effect without providing a function', runFn);
     var effect = new TrackedEffect({ runFn, context });
     this.effects.set(effect.id, effect);
@@ -39,7 +39,7 @@ export default class TrackedEffectsCore {
 
   public stop() {
     this.effects.clear();
-    this.stopWatching(); 
+    this.stopWatching();
   }
 
   private startWatching() {

--- a/addon/classes/use-effect.ts
+++ b/addon/classes/use-effect.ts
@@ -1,0 +1,10 @@
+import TrackedEffectsCore from "./tracked-effects-core";
+import TrackedEffect, { EffectDeps, EffectCallback } from './tracked-effect';
+
+export default function useEffect<D extends any[]>(
+  context: any,
+  effect: EffectCallback<D>,
+  deps?: EffectDeps<D>,
+): TrackedEffect<D> | undefined {
+  return TrackedEffectsCore.instance?.addEffect(context, effect, deps);
+}

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -1,2 +1,3 @@
 export { default as effect } from './classes/tracked-effect-decorator';
 export { default as TrackedEffect } from './classes/tracked-effect';
+export { default as useEffect } from './classes/use-effect';

--- a/addon/services/tracked-effects.ts
+++ b/addon/services/tracked-effects.ts
@@ -1,7 +1,7 @@
 import Service from '@ember/service';
 import TrackedEffectsCore from 'ember-tracked-effects-placeholder/classes/tracked-effects-core';
 import { registerDestructor } from '@ember/destroyable';
-import TrackedEffect from 'ember-tracked-effects-placeholder/classes/tracked-effect';
+import TrackedEffect, { EffectCallback, EffectDeps } from 'ember-tracked-effects-placeholder/classes/tracked-effect';
 import { getOwner } from '@ember/application';
 
 export default class TrackedEffects extends Service {
@@ -21,8 +21,12 @@ export default class TrackedEffects extends Service {
     return TrackedEffectsCore.instance?.isWatching ?? false;
   }
 
-  public addEffect(context: object, runFn: Function): TrackedEffect | undefined {
-    return TrackedEffectsCore.instance?.addEffect(context, runFn);
+  public addEffect<D extends any[]>(
+    context: object,
+    runFn: EffectCallback<D>,
+    deps?: EffectDeps<D>
+  ): TrackedEffect<D> | undefined {
+    return TrackedEffectsCore.instance?.addEffect(context, runFn, deps);
   }
 }
 

--- a/addon/services/tracked-effects.ts
+++ b/addon/services/tracked-effects.ts
@@ -21,8 +21,8 @@ export default class TrackedEffects extends Service {
     return TrackedEffectsCore.instance?.isWatching ?? false;
   }
 
-  public addEffect(runFn: Function, context?: object): TrackedEffect | undefined {
-    return TrackedEffectsCore.instance?.addEffect(runFn, context);
+  public addEffect(context: object, runFn: Function): TrackedEffect | undefined {
+    return TrackedEffectsCore.instance?.addEffect(context, runFn);
   }
 }
 

--- a/tests/unit/services/tracked-effects-test.ts
+++ b/tests/unit/services/tracked-effects-test.ts
@@ -4,26 +4,28 @@ import { tracked } from '@glimmer/tracking';
 import settled from '@ember/test-helpers/settled';
 import Service from '@ember/service';
 import effect from 'ember-tracked-effects-placeholder/classes/tracked-effect-decorator';
+import useEffect from 'ember-tracked-effects-placeholder/classes/use-effect';
 
 class DataSource {
   @tracked value: string = '';
+  @tracked anotherValue: number = 0;
 }
 
 class DataEffectConsumer extends Service {
   result: string = '';
+  anotherResult: number = 0;
 
   @tracked value: string = '';
+  @tracked anotherValue: number = 0;
 
   @effect
   actOnChange = () => {
     this.result = this.value;
   }
-}
 
-async function delay(interval: number) {
-  await new Promise(resolve => {
-    setTimeout(() => { resolve(''); }, interval);
-  });
+  anotherValueEffect = useEffect(this, (value) => {
+    this.anotherResult = value;
+  }, () => [this.anotherValue]);
 }
 
 module('Unit | Service | tracked-effects', function (hooks) {
@@ -61,7 +63,6 @@ module('Unit | Service | tracked-effects', function (hooks) {
     assert.equal(result, 'abc');
     // change the data
     data.value = 'def';
-    await delay(100);
     await settled();
     assert.equal(result, 'def');
     assert.ok(service.isWatching);
@@ -80,22 +81,75 @@ module('Unit | Service | tracked-effects', function (hooks) {
     assert.equal(result, 'abc');
     // change the data
     data.value = 'def';
-    await delay(100);
     await settled();
     assert.equal(result, 'def');
+  });
+
+  test('calls back updates on empty array deps', async function (assert) {
+    let service = this.owner.lookup('service:tracked-effects');
+    var data = new DataSource();
+    data.value = 'abc';
+    var result = '';
+    service.addEffect(
+      null,
+      () => { result = data.value; },
+      () => [],
+    );
+    await settled();
+    assert.equal(result, 'abc', 'The effect should call back the first iteration');
+    // change the data
+    data.value = 'def';
+    await settled();
+    assert.equal(result, 'abc', 'The effect should not call back on any next updates');
+  });
+
+  test('calls back updates on given deps', async function (assert) {
+    let service = this.owner.lookup('service:tracked-effects');
+    var data = new DataSource();
+    data.value = 'abc';
+    data.anotherValue = 5;
+    var result = '';
+    var anotherResult = 0;
+    service.addEffect(
+      null,
+      () => {
+        result = data.value;
+        anotherResult = data.anotherValue;
+      },
+      () => [data.anotherValue],
+    );
+    await settled();
+    assert.equal(result, 'abc', 'The effect should call back the first iteration');
+    assert.equal(anotherResult, 5, 'The effect should call back the first iteration');
+    // change the data that is not consuming in the deps
+    data.value = 'def';
+    await settled();
+    assert.equal(result, 'abc', 'The effect should not reflect on unspecified deps');
+    assert.equal(anotherResult, 5, 'The effect should not reflect on unspecified deps');
+    // change the data consuming in the deps
+    data.anotherValue = 10;
+    await settled();
+    assert.equal(result, 'def', 'The effect should reflect on given deps');
+    assert.equal(anotherResult, 10, 'The effect should reflect on given deps');
   });
 
   test('calls back on data update with decorator', async function (assert) {
     var data = new DataEffectConsumer();
     data.value = 'abc';
-    await delay(100);
+    data.anotherValue = 5;
     await settled();
     assert.equal(data.result, 'abc');
+    assert.equal(data.anotherResult, 5);
     // change the data
     data.value = 'def';
-    await delay(100);
     await settled();
     assert.equal(data.result, 'def');
+    assert.equal(data.anotherResult, 5);
+    // change anotherValue
+    data.anotherValue = 10;
+    await settled();
+    assert.equal(data.result, 'def');
+    assert.equal(data.anotherResult, 10);
   });
 
   test('stopping an effect means callback is not called', async function (assert) {
@@ -115,7 +169,6 @@ module('Unit | Service | tracked-effects', function (hooks) {
 
     // change the data
     data.value = 'def';
-    await delay(100);
     await settled();
     assert.equal(result, 'abc');
     assert.notOk(service.isWatching);
@@ -125,13 +178,11 @@ module('Unit | Service | tracked-effects', function (hooks) {
     let service = this.owner.lookup('service:tracked-effects');
     var data = new DataEffectConsumer();
     data.value = 'abc';
-    await delay(100);
     await settled();
     assert.equal(data.result, 'abc');
 
     // change the data
     data.value = 'def';
-    await delay(100);
     await settled();
     assert.equal(data.result, 'def');
     assert.ok(service.isWatching);

--- a/tests/unit/services/tracked-effects-test.ts
+++ b/tests/unit/services/tracked-effects-test.ts
@@ -11,10 +11,10 @@ class DataSource {
 
 class DataEffectConsumer extends Service {
   result: string = '';
-  
+
   @tracked value: string = '';
 
-  @effect 
+  @effect
   actOnChange = () => {
     this.result = this.value;
   }
@@ -40,6 +40,7 @@ module('Unit | Service | tracked-effects', function (hooks) {
     data.value = 'abc';
     var result = '';
     service.addEffect(
+      null,
       () => { result = data.value; }
     );
     await settled();
@@ -53,6 +54,7 @@ module('Unit | Service | tracked-effects', function (hooks) {
     data.value = 'abc';
     var result = '';
     service.addEffect(
+      null,
       () => { result = data.value; }
     );
     await settled();
@@ -71,6 +73,7 @@ module('Unit | Service | tracked-effects', function (hooks) {
     data.value = 'abc';
     var result = '';
     service.addEffect(
+      null,
       () => { result = data.value; }
     );
     await settled();
@@ -101,6 +104,7 @@ module('Unit | Service | tracked-effects', function (hooks) {
     data.value = 'abc';
     var result = '';
     var effect = service.addEffect(
+      null,
       () => { result = data.value; }
     );
     await settled();
@@ -134,7 +138,7 @@ module('Unit | Service | tracked-effects', function (hooks) {
 
     // destroy the consumer
     data.destroy();
-    
+
     await settled();
     // that was the last effect so the service shouldn't be watching
     assert.notOk(service.isWatching);
@@ -145,12 +149,12 @@ module('Unit | Service | tracked-effects', function (hooks) {
       // @ts-ignore
       // eslint-disable-next-line
       class BrokenConsumer extends Service {
-        @effect 
+        @effect
         actOnChange() {
         }
       }
-    }, 
-    /.*BrokenConsumer.*actOnChange().*/, 
+    },
+    /.*BrokenConsumer.*actOnChange().*/,
     'error message contains class and method name');
   })
 });


### PR DESCRIPTION
The main reason I want to have it there is `deps` function to control the effect explicitly and say when this effect should be called. Another reason is a full typescript coverage, as there are no decorators and no implicit type changes.

Usage:

`useEffect` can be **autotracked** or **controlled**
1. To have a **controlled** effect you'll need to pass the `deps` function (`() => [trackedProp1, trackedProp2]`). If any of these properties is updated it'll trigger the new effect.
   Note, the property can be updated, but the value can be the same (`this.prop = this.prop`), it'll trigger the effect anyway. To prevent this you can use the `dedupeTracked` decorator from https://github.com/tracked-tools/tracked-toolbox instead. 

   To have the effect on mount only, pass the function with empty array (`() => []`).

   Passing non-tracked properties to this array has no effect on updates.

   The deps array is also passed to the effect function as arguments. (`useEffect(this, (prop1, prop2) => {...}, () => [prop1, prop2]`)
2. If you don't pass the deps argument, the effect will be **autotracked**, so it will trigger the function whenever any tracked property in the effect is updated.

   Be careful with this effect if you are using more than 1 tracked property inside the effect as it can be complicated to investigate what property triggers the update. Use controlled effect there instead.

```ts
import Component from '@glimmer/component';
import { tracked } from '@glimmer/tracking';
import { useEffect } from 'ember-tracked-effects-placeholder';
interface Args {
  id: string;
}
export default class MyComponent extends Component<Args> {
  @tracked input = '';
  constructor(owner, args) {
    super(owner, args);
    
    // constructor style
    useEffect(this, () => {
      // some code
    });
  }
  
  /* property assignment style */
  autotrackedEffect = useEffect(this, () => {
    console.log('this is called whenever @id or this.input is updated');
    console.log(this.args.id, this.input); // consume this.args.id and this.input
  }); // no consumer
  mountEffect = useEffect(this, () => {
    console.log('this is called only on mount and is neved updated');
    console.log(this.args.id, this.input); // it doesn't matter what you call here
  }, () => []); // empty array consumer
  idEffect = useEffect(this, () => {
    console.log('this is called whenever @id is updated');
    console.log('it is safe to use any other tracked properties', this.args.id, this.input);
  }, () => [this.args.id]); // consume @id only
}
```